### PR TITLE
Support windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ $ tail -f /var/log/td-agent/td-agent.log
 * keys (Optional)
   * output record keys of the ps command results
   * [default] Linux, MacOSX: `start_time,user,pid,parent_pid,cpu_time,cpu_percent,memory_percent,mem_rss,mem_size,state,proc_name,command`
-    * need to fix `command` to match this.
+    * need to modify `command` too if you modify this value.
   * [default] Windows: `start_time,user,sid,pid,cpu_second,working_set,virtual_memory_size,handles,proc_name`
     * in Windows only, you can fix this without fixing `command`, unless you specify a key other than the default.
     * `user` key needs administrator privilege. You can exclude this to avoid needing administrator privilege.

--- a/README.md
+++ b/README.md
@@ -68,14 +68,20 @@ $ tail -f /var/log/td-agent/td-agent.log
   * execute ps command with some options
   * [default] Linux: `LANG=en_US.UTF-8 && ps -ewwo lstart,user:20,pid,ppid,time,%cpu,%mem,rss,sz,s,comm,cmd`
   * [default] MacOSX: `LANG=en_US.UTF-8 && ps -ewwo lstart,user,pid,ppid,time,%cpu,%mem,rss,vsz,state,comm,command`
+  * [default] Windows: described in the next section, `About Windows`.
 
 * keys (Optional)
   * output record keys of the ps command results
-  * [default] start_time user pid parent_pid cpu_time cpu_percent memory_percent mem_rss mem_size state proc_name command
+  * [default] Linux, MacOSX: `start_time,user,pid,parent_pid,cpu_time,cpu_percent,memory_percent,mem_rss,mem_size,state,proc_name,command`
+    * need to fix `command` to match this.
+  * [default] Windows: `start_time,user,sid,pid,cpu_second,working_set,virtual_memory_size,handles,proc_name`
+    * in Windows only, you can fix this without fixing `command`, unless you specify a key other than the default.
+    * `user` key needs administrator privilege. You can exclude this to avoid needing administrator privilege.
 
 * types (Optional)
   * settings of converting types from string to integer/float.
-  * [default] pid:integer parent_pid:integer cpu_percent:float memory_percent:float mem_rss:integer mem_size:integer
+  * [default] Linux, MacOSX: `pid:integer,parent_pid:integer,cpu_percent:float,memory_percent:float,mem_rss:integer,mem_size:integer`
+  * [default] Windows: `sid:integer,pid:integer,cpu_second:float,working_set:integer,virtual_memory_size:integer,handles:integer`
 
 * interval (Optional)
   * execute interval time
@@ -89,6 +95,43 @@ $ tail -f /var/log/td-agent/td-agent.log
   * settings for tag placeholder, `${hostname}` and `__HOSTNAME__`. By default, it using long hostname.
   * to use short hostname, set `hostname -s` for this option on linux/mac.
   * [default] `hostname`
+
+### About Windows
+
+Default `command` in Windows below is complicated, but you can fix `keys` without fixing `command`, unless you specify a key other than the default.
+
+`````powershell
+powershell -command "Get-Process -IncludeUserName
+ | ?{$_.StartTime -ne $NULL -and $_.CPU -ne $NULL}
+ | Select-Object -Property StartTime,UserName,SessionId,Id,CPU,WorkingSet,VirtualMemorySize,HandleCount,ProcessName
+ | %{
+  $_.StartTime = $_.StartTime.ToString(
+  'ddd MMM dd HH:mm:ss yyyy',
+  [Globalization.CultureInfo]::GetCultureInfo('en-US').DateTimeFormat
+  );
+  return $_;
+} | ConvertTo-Csv -NoTypeInformation"
+`````
+
+Here are details of this default command.
+
+* `Get-Process -IncludeUserName`
+  * `Get-Process` powershell command takes `System.Diagnostics.Process` objects.
+  * `IncludeUserName` option is needed to take `UserName` (key:`user`).
+    * this needs administrator privilege.
+    * this will be omitted if `keys` does not contain `user`.
+* ` | ?{$_.StartTime -ne $NULL -and $_.CPU -ne $NULL}`
+  * this exlcludes some special processes that don't have some properties, such as the "Idle" process in Windows.
+* ` | Select-Object -Property ...`
+  * this takes the necessary parameters from `System.Diagnostics.Process` objects.
+  * `...` part will be automatically fixed by `keys`, unless you specify a key other than the default.
+* ` | %{$_.StartTime = ...; return $_;}`
+  * this fixes locale of `StartTime` value to `en-US`.
+  * note: in Windows, setting the "$env:Lang" environment variable is not effective in changing the format of the output.
+* ` | ConvertTo-Csv -NoTypeInformation`
+  * this formats objects to csv strings.
+  * currently, it is needed that `command` outputs the results in csv format.
+    * this is because white space delimiter is not suitable for Windows, in which empty values are often mixed.
 
 ## FAQ
 

--- a/lib/fluent/plugin/in_watch_process.rb
+++ b/lib/fluent/plugin/in_watch_process.rb
@@ -1,4 +1,5 @@
 require 'time'
+require 'csv'
 require "fluent/plugin/input"
 require 'fluent/mixin/rewrite_tag_name'
 require 'fluent/mixin/type_converter'
@@ -8,8 +9,6 @@ module Fluent::Plugin
     Fluent::Plugin.register_input('watch_process', self)
 
     helpers :timer
-
-    DEFAULT_TYPES = "pid:integer,parent_pid:integer,cpu_percent:float,memory_percent:float,mem_rss:integer,mem_size:integer"
 
     config_param :tag, :string
     config_param :command, :string, :default => nil
@@ -21,7 +20,6 @@ module Fluent::Plugin
     include Fluent::HandleTagNameMixin
     include Fluent::Mixin::RewriteTagName
     include Fluent::Mixin::TypeConverter
-    config_set_default :types, DEFAULT_TYPES
 
     def initialize
       super
@@ -60,6 +58,8 @@ module Fluent::Plugin
           Linux.new(keys, command)
         elsif OS.mac?
           Mac.new(keys, command)
+        elsif OS.windows?
+          Windows.new(keys, command)
         else
           raise NotImplementedError, "This OS type is not supported."
         end
@@ -103,6 +103,7 @@ module Fluent::Plugin
 
       class BaseUnixLike < Base
         DEFAULT_KEYS = %w(start_time user pid parent_pid cpu_time cpu_percent memory_percent mem_rss mem_size state proc_name command)
+        DEFAULT_TYPES = "pid:integer,parent_pid:integer,cpu_percent:float,memory_percent:float,mem_rss:integer,mem_size:integer"
 
         def initialize(keys, command)
           super(keys, command)
@@ -141,6 +142,97 @@ module Fluent::Plugin
         def initialize(keys, command)
           super(keys, command)
           @command = @command || DEFAULT_COMMAND
+        end
+      end
+
+      class Windows < Base
+        # Values are from the "System.Diagnostics.Process" object properties that can be taken by the "Get-Process" command.
+        # You can check the all properties by the "(Get-Process)[0] | Get-Member" command.
+        DEFAULT_PARAMS = {
+          "start_time" => "StartTime",
+          "user" => "UserName",
+          "sid" => "SessionId",
+          "pid" => "Id",
+          "cpu_second" => "CPU",
+          "working_set" => "WorkingSet",
+          "virtual_memory_size" => "VirtualMemorySize",
+          "handles" => "HandleCount",
+          "proc_name" => "ProcessName",
+        }
+        DEFAULT_TYPES = "sid:integer,pid:integer,cpu_second:float,working_set:integer,virtual_memory_size:integer,handles:integer"
+
+        def initialize(keys, command)
+          super(keys, command)
+          @keys = @keys || DEFAULT_PARAMS.keys
+          @command = @command || default_command
+        end
+
+        def parse_line(line)
+          values = line.chomp.strip.parse_csv.map { |e| e ? e : "" }
+          Hash[@keys.zip(values)]
+        end
+
+        def default_command
+          command = [
+            command_ps,
+            pipe_filtering_normal_ps,
+            pipe_select_columns,
+            pipe_fixing_locale,
+            pipe_formatting_output,
+          ].join
+          "powershell -command \"#{command}\""
+        end
+
+        private
+
+        def command_ps
+          if @keys.include?("user")
+            # The "IncludeUserName" option is needed to get the username, but this option requires Administrator privilege.
+            "Get-Process -IncludeUserName"
+          else
+            "Get-Process"
+          end
+        end
+
+        def pipe_filtering_normal_ps
+          # There are some special processes that don't have some properties, such as the "Idle" process.
+          # Normally, these are specific to the system and are not important, so exclude them.
+          # Note: The same situation can occur in some processes if there are no Administrator privilege.
+          " | ?{$_.StartTime -ne $NULL -and $_.CPU -ne $NULL}"
+        end
+
+        def pipe_select_columns
+          columns = DEFAULT_PARAMS.keys.map { |key|
+            next unless @keys.include?(key)
+            DEFAULT_PARAMS[key]
+          }.compact
+
+          if columns.nil? || columns.empty?
+            raise "The 'keys' parameter is not specified correctly. [keys: #{@keys}]"
+          end
+
+          " | Select-Object -Property #{columns.join(',')}"
+        end
+
+        def pipe_fixing_locale(format: "ddd MMM dd HH:mm:ss yyyy", locale: "en-US")
+          # In Windows, setting the "$env:Lang" environment variable is not effective in changing the format of the output.
+          # You can use "Datetime.ToString" method to change format of datetime values in for-each pipe.
+          # Note: About "DateTime.ToString" method: https://docs.microsoft.com/en-us/dotnet/api/system.datetime.tostring
+          # Note: About "Custom date and time format strings": https://docs.microsoft.com/en-us/dotnet/standard/base-types/custom-date-and-time-format-strings
+          " | %{
+            $_.StartTime = $_.StartTime.ToString(
+              '#{format}',
+              [Globalization.CultureInfo]::GetCultureInfo('#{locale}').DateTimeFormat
+            ); 
+            return $_;
+          }"
+        end
+
+        def pipe_formatting_output
+          # In the "ConvertTo-Csv" command, there are 2 lines of type info and header info at the beginning in the outputs.
+          # By the "NoTypeInformation" option, the line of type info is excluded.
+          # This enables you to skip the just first line for parsing, like linux or mac.
+          " | ConvertTo-Csv -NoTypeInformation"
         end
       end
 

--- a/lib/fluent/plugin/in_watch_process.rb
+++ b/lib/fluent/plugin/in_watch_process.rb
@@ -202,8 +202,8 @@ module Fluent::Plugin
         end
 
         def pipe_select_columns
-          columns = DEFAULT_PARAMS.keys.map { |key|
-            next unless @keys.include?(key)
+          columns = @keys.map { |key|
+            next unless DEFAULT_PARAMS.keys.include?(key)
             DEFAULT_PARAMS[key]
           }.compact
 

--- a/lib/fluent/plugin/in_watch_process.rb
+++ b/lib/fluent/plugin/in_watch_process.rb
@@ -68,7 +68,7 @@ module Fluent::Plugin
         elsif OS.windows?
           Windows.new(keys, command)
         else
-          raise NotImplementedError, "This OS type is not supported."
+          Linux.new(keys, command)
         end
       end
 

--- a/lib/fluent/plugin/in_watch_process.rb
+++ b/lib/fluent/plugin/in_watch_process.rb
@@ -219,6 +219,9 @@ module Fluent::Plugin
           # You can use "Datetime.ToString" method to change format of datetime values in for-each pipe.
           # Note: About "DateTime.ToString" method: https://docs.microsoft.com/en-us/dotnet/api/system.datetime.tostring
           # Note: About "Custom date and time format strings": https://docs.microsoft.com/en-us/dotnet/standard/base-types/custom-date-and-time-format-strings
+          unless @keys.include?("start_time")
+            return ""
+          end
           " | %{
             $_.StartTime = $_.StartTime.ToString(
               '#{format}',

--- a/lib/fluent/plugin/in_watch_process.rb
+++ b/lib/fluent/plugin/in_watch_process.rb
@@ -200,7 +200,13 @@ module Fluent::Plugin
 
         def parse_line(line)
           values = line.chomp.strip.parse_csv.map { |e| e ? e : "" }
-          Hash[@keys.zip(values)]
+          data = Hash[@keys.zip(values)]
+
+          unless data["start_time"].nil?
+            data["start_time"] = format_datetime(data["start_time"])
+          end
+
+          data
         end
 
         def default_command
@@ -215,6 +221,10 @@ module Fluent::Plugin
         end
 
         private
+
+        def format_datetime(datetime)
+          Time.parse(datetime).to_s
+        end
 
         def command_ps
           if @keys.include?("user")

--- a/lib/fluent/plugin/in_watch_process.rb
+++ b/lib/fluent/plugin/in_watch_process.rb
@@ -1,5 +1,5 @@
 require 'time'
-require 'csv'
+require 'csv' if Fluent.windows?
 require "fluent/plugin/input"
 require 'fluent/mixin/rewrite_tag_name'
 require 'fluent/mixin/type_converter'
@@ -117,11 +117,18 @@ module Fluent::Plugin
 
         def initialize(keys, command)
           super(keys, command)
-          @keys = @keys || DEFAULT_KEYS
+          @keys ||= DEFAULT_KEYS
         end
 
         def default_types
-          "pid:integer,parent_pid:integer,cpu_percent:float,memory_percent:float,mem_rss:integer,mem_size:integer"
+          %w(
+            pid:integer
+            parent_pid:integer
+            cpu_percent:float
+            memory_percent:float
+            mem_rss:integer
+            mem_size:integer
+          ).join(",")
         end
 
         def parse_line(line)
@@ -146,7 +153,7 @@ module Fluent::Plugin
 
         def initialize(keys, command)
           super(keys, command)
-          @command = @command || DEFAULT_COMMAND
+          @command ||= DEFAULT_COMMAND
         end
       end
 
@@ -155,7 +162,7 @@ module Fluent::Plugin
 
         def initialize(keys, command)
           super(keys, command)
-          @command = @command || DEFAULT_COMMAND
+          @command ||= DEFAULT_COMMAND
         end
       end
 
@@ -176,12 +183,19 @@ module Fluent::Plugin
 
         def initialize(keys, command)
           super(keys, command)
-          @keys = @keys || DEFAULT_PARAMS.keys
-          @command = @command || default_command
+          @keys ||= DEFAULT_PARAMS.keys
+          @command ||= default_command
         end
 
         def default_types
-          "sid:integer,pid:integer,cpu_second:float,working_set:integer,virtual_memory_size:integer,handles:integer"
+          %w(
+            sid:integer
+            pid:integer
+            cpu_second:float
+            working_set:integer
+            virtual_memory_size:integer
+            handles:integer
+          ).join(",")
         end
 
         def parse_line(line)
@@ -236,9 +250,8 @@ module Fluent::Plugin
           # You can use "Datetime.ToString" method to change format of datetime values in for-each pipe.
           # Note: About "DateTime.ToString" method: https://docs.microsoft.com/en-us/dotnet/api/system.datetime.tostring
           # Note: About "Custom date and time format strings": https://docs.microsoft.com/en-us/dotnet/standard/base-types/custom-date-and-time-format-strings
-          unless @keys.include?("start_time")
-            return ""
-          end
+          return "" unless @keys.include?("start_time")
+
           " | %{
             $_.StartTime = $_.StartTime.ToString(
               '#{format}',

--- a/lib/fluent/plugin/in_watch_process.rb
+++ b/lib/fluent/plugin/in_watch_process.rb
@@ -61,15 +61,17 @@ module Fluent::Plugin
 
     module Watcher
       def self.get_watcher(keys, command)
-        if OS.linux?
-          Linux.new(keys, command)
-        elsif OS.mac?
+        if mac?
           Mac.new(keys, command)
-        elsif OS.windows?
+        elsif Fluent.windows?
           Windows.new(keys, command)
         else
           Linux.new(keys, command)
         end
+      end
+
+      def self.mac?
+        (/darwin/ =~ RUBY_PLATFORM) != nil
       end
 
       class Base
@@ -276,25 +278,6 @@ module Fluent::Plugin
           # By the "NoTypeInformation" option, the line of type info is excluded.
           # This enables you to skip the just first line for parsing, like linux or mac.
           " | ConvertTo-Csv -NoTypeInformation"
-        end
-      end
-
-      module OS
-        # ref. http://stackoverflow.com/questions/170956/how-can-i-find-which-operating-system-my-ruby-program-is-running-on
-        def self.windows?
-          (/cygwin|mswin|mingw|bccwin|wince|emx/ =~ RUBY_PLATFORM) != nil
-        end
-
-        def self.mac?
-         (/darwin/ =~ RUBY_PLATFORM) != nil
-        end
-
-        def self.unix?
-          !windows?
-        end
-
-        def self.linux?
-          unix? and not mac?
         end
       end
     end

--- a/test/plugin/test_in_watch_process.rb
+++ b/test/plugin/test_in_watch_process.rb
@@ -26,7 +26,7 @@ class WatchProcessInputTest < Test::Unit::TestCase
   end
 
   def test_unixlike
-    return if Fluent.windows?
+    omit "Only for UNIX like." if Fluent.windows?
     whoami = `whoami`
     d = create_driver %[
       tag          input.watch_process
@@ -37,74 +37,76 @@ class WatchProcessInputTest < Test::Unit::TestCase
     assert(d.events.size > 1)
   end
 
-  def test_windows_default
-    return unless Fluent.windows?
-    d = create_driver %[
-      tag input.watch_process
-      interval 1s
-    ]
-    default_keys = Fluent::Plugin::WatchProcessInput::Watcher::Windows::DEFAULT_PARAMS.keys
+  sub_test_case "Windows" do
+    def test_windows_default
+      omit "Only for Windows." unless Fluent.windows?
+      d = create_driver %[
+        tag input.watch_process
+        interval 1s
+      ]
+      default_keys = Fluent::Plugin::WatchProcessInput::Watcher::Windows::DEFAULT_PARAMS.keys
 
-    d.run(expect_records: 1, timeout: 10);
+      d.run(expect_records: 1, timeout: 10);
 
-    assert d.events.size > 0
+      assert d.events.size > 0
 
-    tag, time, record = d.events[0]
+      tag, time, record = d.events[0]
 
-    assert_equal "input.watch_process", tag
-    assert time.is_a?(Fluent::EventTime)
-    assert_equal default_keys, record.keys
-  end
-
-  def test_windows_customized
-    return unless Fluent.windows?
-    custom_keys = ["handles", "pid", "proc_name"]
-    d = create_driver %[
-      tag input.watch_process
-      interval 1s
-      keys #{custom_keys.join(",")}
-      types pid:integer
-    ]
-
-    d.run(expect_records: 1, timeout: 10);
-
-    assert d.events.size > 0
-
-    tag, time, record = d.events[0]
-
-    assert_equal "input.watch_process", tag
-    assert time.is_a?(Fluent::EventTime)
-    assert_equal custom_keys, record.keys
-    assert record["handles"].is_a?(String)
-    assert record["pid"].is_a?(Integer)
-  end
-
-  def test_windows_lookup
-    return unless Fluent.windows?
-    d = create_driver %[
-      tag input.watch_process
-      interval 1s
-    ]
-    d.run(expect_records: 1, timeout: 10);
-
-    assert d.events.size > 0
-
-    tag, time, record = d.events[0]
-    lookup_user = record["user"]
-
-    d = create_driver %[
-      tag input.watch_process
-      interval 1s
-      lookup_user #{lookup_user}
-    ]
-    d.run(expect_records: 1, timeout: 10);
-
-    assert d.events.size > 0
-
-    other_user_records = d.events.reject do |tag, time, record|
-      lookup_user.include?(record["user"])
+      assert_equal "input.watch_process", tag
+      assert time.is_a?(Fluent::EventTime)
+      assert_equal default_keys, record.keys
     end
 
-    assert other_user_records.size == 0
+    def test_windows_customized
+      omit "Only for Windows." unless Fluent.windows?
+      custom_keys = ["handles", "pid", "proc_name"]
+      d = create_driver %[
+        tag input.watch_process
+        interval 1s
+        keys #{custom_keys.join(",")}
+        types pid:integer
+      ]
+
+      d.run(expect_records: 1, timeout: 10);
+
+      assert d.events.size > 0
+
+      tag, time, record = d.events[0]
+
+      assert_equal "input.watch_process", tag
+      assert time.is_a?(Fluent::EventTime)
+      assert_equal custom_keys, record.keys
+      assert record["handles"].is_a?(String)
+      assert record["pid"].is_a?(Integer)
+    end
+
+    def test_windows_lookup
+      omit "Only for Windows." unless Fluent.windows?
+      d = create_driver %[
+        tag input.watch_process
+        interval 1s
+      ]
+      d.run(expect_records: 1, timeout: 10);
+
+      assert d.events.size > 0
+
+      tag, time, record = d.events[0]
+      lookup_user = record["user"]
+
+      d = create_driver %[
+        tag input.watch_process
+        interval 1s
+        lookup_user #{lookup_user}
+      ]
+      d.run(expect_records: 1, timeout: 10);
+
+      assert d.events.size > 0
+
+      other_user_records = d.events.reject do |tag, time, record|
+        lookup_user.include?(record["user"])
+      end
+
+      assert other_user_records.size == 0
+    end
   end
 end

--- a/test/plugin/test_in_watch_process.rb
+++ b/test/plugin/test_in_watch_process.rb
@@ -25,7 +25,8 @@ class WatchProcessInputTest < Test::Unit::TestCase
     assert_equal ['apache', 'mycron'], d.instance.lookup_user
   end
 
-  def test_emit
+  def test_unixlike
+    return if Fluent.windows?
     whoami = `whoami`
     d = create_driver %[
       tag          input.watch_process
@@ -34,5 +35,76 @@ class WatchProcessInputTest < Test::Unit::TestCase
     ]
     d.run(expect_emits: 1, timeout: 3)
     assert(d.events.size > 1)
+  end
+
+  def test_windows_default
+    return unless Fluent.windows?
+    d = create_driver %[
+      tag input.watch_process
+      interval 1s
+    ]
+    default_keys = Fluent::Plugin::WatchProcessInput::Watcher::Windows::DEFAULT_PARAMS.keys
+
+    d.run(expect_records: 1, timeout: 10);
+
+    assert d.events.size > 0
+
+    tag, time, record = d.events[0]
+
+    assert_equal "input.watch_process", tag
+    assert time.is_a?(Fluent::EventTime)
+    assert_equal default_keys, record.keys
+  end
+
+  def test_windows_customized
+    return unless Fluent.windows?
+    custom_keys = ["handles", "pid", "proc_name"]
+    d = create_driver %[
+      tag input.watch_process
+      interval 1s
+      keys #{custom_keys.join(",")}
+      types pid:integer
+    ]
+
+    d.run(expect_records: 1, timeout: 10);
+
+    assert d.events.size > 0
+
+    tag, time, record = d.events[0]
+
+    assert_equal "input.watch_process", tag
+    assert time.is_a?(Fluent::EventTime)
+    assert_equal custom_keys, record.keys
+    assert record["handles"].is_a?(String)
+    assert record["pid"].is_a?(Integer)
+  end
+
+  def test_windows_lookup
+    return unless Fluent.windows?
+    d = create_driver %[
+      tag input.watch_process
+      interval 1s
+    ]
+    d.run(expect_records: 1, timeout: 10);
+
+    assert d.events.size > 0
+
+    tag, time, record = d.events[0]
+    lookup_user = record["user"]
+
+    d = create_driver %[
+      tag input.watch_process
+      interval 1s
+      lookup_user #{lookup_user}
+    ]
+    d.run(expect_records: 1, timeout: 10);
+
+    assert d.events.size > 0
+
+    other_user_records = d.events.reject do |tag, time, record|
+      lookup_user.include?(record["user"])
+    end
+
+    assert other_user_records.size == 0
   end
 end


### PR DESCRIPTION
I recreated this from [Add Windows default command](https://github.com/daipom/fluent-plugin-watch-process/pull/1).

I am still in the process of implementing this feature.

TODO

- [X] remove the empty lines from io
- [X] consider adjusting DEFAULT_KEYS for Windows
- [X] consider simplifying default ps command for Windows, and separate plugin if need
- [x] fix README
- [x] reflect type setting
- [ ] consider making diff smaller
- [x] apply feedbacks
- [x] create test code
